### PR TITLE
Replace remaining compose calls with append

### DIFF
--- a/qiskit/aqua/algorithms/factorizers/shor.py
+++ b/qiskit/aqua/algorithms/factorizers/shor.py
@@ -121,7 +121,7 @@ class Shor(QuantumAlgorithm):
                                          num_qubits: int,
                                          angles: Union[np.ndarray, ParameterVector]
                                          ) -> QuantumCircuit:
-        """Implements double-controlled modular addition by a, returning the circuit."""
+        """Creates a circuit which implements double-controlled modular addition by a."""
         circuit = QuantumCircuit(num_qubits, name="phi_add")
 
         ctl_up = 0
@@ -155,7 +155,7 @@ class Shor(QuantumAlgorithm):
         return circuit
 
     def _controlled_multiple_mod_N(self, num_qubits: int, a: int) -> Instruction:
-        """Gate that implements modular multiplication by a."""
+        """Implements modular multiplication by a as an instruction."""
         circuit = QuantumCircuit(
             num_qubits, name="multiply_by_{}_mod_{}".format(a % self._N, self._N)
         )

--- a/qiskit/aqua/algorithms/factorizers/shor.py
+++ b/qiskit/aqua/algorithms/factorizers/shor.py
@@ -92,7 +92,7 @@ class Shor(QuantumAlgorithm):
             logger.info('The input integer is a power: %s=%s^%s.', N, b, p)
             self._ret['factors'].append(b)
 
-        self._qft = QFT(do_swaps=False)
+        self._qft = QFT(do_swaps=False).to_instruction()
         self._iqft = self._qft.inverse()
 
         self._phi_add_N = None

--- a/qiskit/aqua/algorithms/factorizers/shor.py
+++ b/qiskit/aqua/algorithms/factorizers/shor.py
@@ -22,7 +22,7 @@ import logging
 import numpy as np
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.circuit import Gate, ParameterVector
+from qiskit.circuit import Gate, Instruction, ParameterVector
 from qiskit.circuit.library import QFT
 from qiskit.providers import BaseBackend
 from qiskit.aqua import QuantumInstance
@@ -137,24 +137,24 @@ class Shor(QuantumAlgorithm):
 
         circuit.append(phi_add_a.control(2), [ctl_up, ctl_down, *qubits])
         circuit.append(self._iphi_add_N, qubits)
-        circuit.compose(self._iqft, qubits, inplace=True)
+        circuit.append(self._iqft, qubits)
 
         circuit.cx(qubits[0], ctl_aux)
 
-        circuit.compose(self._qft, qubits, inplace=True)
+        circuit.append(self._qft, qubits)
         circuit.append(self._phi_add_N, qubits)
         circuit.append(iphi_add_a.control(2), [ctl_up, ctl_down, *qubits])
-        circuit.compose(self._iqft, qubits, inplace=True)
+        circuit.append(self._iqft, qubits)
 
         circuit.x(qubits[0])
         circuit.cx(qubits[0], ctl_aux)
         circuit.x(qubits[0])
 
-        circuit.compose(self._qft, qubits, inplace=True)
+        circuit.append(self._qft, qubits)
         circuit.append(phi_add_a.control(2), [ctl_up, ctl_down, *qubits])
         return circuit
 
-    def _controlled_multiple_mod_N_gate(self, num_qubits: int, a: int) -> Gate:
+    def _controlled_multiple_mod_N_gate(self, num_qubits: int, a: int) -> Instruction:
         """Gate that implements modular multiplication by a."""
         circuit = QuantumCircuit(
             num_qubits, name="multiply_by_{}_mod_{}".format(a % self._N, self._N)
@@ -194,7 +194,7 @@ class Shor(QuantumAlgorithm):
             circuit.compose(bound, [ctl_up, down[i], ctl_aux, *qubits], inplace=True)
 
         circuit.compose(self._iqft, qubits, inplace=True)
-        return circuit.to_gate()
+        return circuit.to_instruction()
 
     def construct_circuit(self, measurement: bool = False) -> QuantumCircuit:
         """Construct circuit.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
-Converts `qft` blueprints to instruction and replaces all remaining `.compose` calls with the faster `.append` in Shor's algorithm

### Details and comments


